### PR TITLE
findAndModify now returns T | null instead of T | undefined

### DIFF
--- a/src/collection/collection.ts
+++ b/src/collection/collection.ts
@@ -68,7 +68,7 @@ export class Collection<T extends Document> {
   async findAndModify(
     filter?: Filter<T>,
     options?: FindAndModifyOptions<T>,
-  ): Promise<T | undefined> {
+  ): Promise<T | null> {
     const result = await this.#protocol.commandSingle<{
       value: T;
       ok: number;

--- a/tests/cases/03_curd.ts
+++ b/tests/cases/03_curd.ts
@@ -207,6 +207,25 @@ testWithTestDBClient("testInsertMany", async (db) => {
   assertEquals(insertedIds.length, 2);
 });
 
+testWithTestDBClient("testFindAndModify-notfound", async (db) => {
+  const users = db.collection<{ username: string; counter: number }>(
+    "mongo_test_users",
+  );
+
+  const find = await users.findAndModify(
+    {
+      // this query matches no document
+      $and: [{ username: "a" }, { username: "b" }],
+    },
+    {
+      new: false,
+    },
+  );
+
+  assert(find === null);
+  assert(find !== undefined);
+});
+
 testWithTestDBClient("testFindAndModify-update", async (db) => {
   const users = db.collection<{ username: string; counter: number }>(
     "mongo_test_users",

--- a/tests/cases/03_curd.ts
+++ b/tests/cases/03_curd.ts
@@ -218,6 +218,7 @@ testWithTestDBClient("testFindAndModify-notfound", async (db) => {
       $and: [{ username: "a" }, { username: "b" }],
     },
     {
+      update: { $inc: { counter: 1 } },
       new: false,
     },
   );

--- a/tests/cases/03_curd.ts
+++ b/tests/cases/03_curd.ts
@@ -217,7 +217,7 @@ testWithTestDBClient("testFindAndModify-update", async (db) => {
     new: true,
   });
 
-  assert(updated !== undefined);
+  assert(updated !== null);
   assertEquals(updated.counter, 6);
   assertEquals(updated.username, "counter");
 });
@@ -231,7 +231,7 @@ testWithTestDBClient("testFindAndModify-delete", async (db) => {
     remove: true,
   });
 
-  assert(updated !== undefined);
+  assert(updated !== null);
   assertEquals(updated.counter, 10);
   assertEquals(updated.username, "delete");
 


### PR DESCRIPTION
According to [the Official document of mongoDB](https://www.mongodb.com/docs/manual/reference/method/db.collection.findAndModify/#return-data), findAndModify returns the document or **null**.


I test this problem by below code:
```ts
const collection = /*...*/;
const result = await collection.findAndModify(
  {
    name: 'abc',
  },
  {
    update: {
      $set: {
        'someField': 12345,
      },
    },
    new: false,
  },
);
```
I've confirmed that the result is a pre-updated document if the document matches `{ name: 'abc' }` found, if not, the result is certainly null.

Maybe, the return type should be `Promise<T | null>`.


Last but not least, I apologize if there are any mistakes in my English writing. I am just Japanese student learning English ;)